### PR TITLE
【feature/MYFAVE-92】ユーザーに紐づく通知一覧取得

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ProfileRequest;
+use App\Models\User;
 use App\Repositories\User\UserRepositoryInterface;
 use App\Modules\ApplicationLogger;
 use App\ViewModel\UserViewModel;
@@ -55,5 +56,21 @@ class UserController extends Controller
 
         $logger->success();
         return response()->json($editProfile);
+    }
+
+    /**
+     * 通知一覧の取得
+     *
+     * @return JsonResponse
+     */
+    public function notifications(): JsonResponse
+    {
+        $logger = new ApplicationLogger(__METHOD__);
+
+        $logger->write('通知一覧の取得処理を開始');
+        $notifications = $this->userRepository->fetchNotifications();
+
+        $logger->success();
+        return response()->json($notifications);
     }
 }

--- a/backend/app/Repositories/User/UserRepository.php
+++ b/backend/app/Repositories/User/UserRepository.php
@@ -4,7 +4,6 @@ namespace App\Repositories\User;
 
 use App\Http\Requests\ProfileRequest;
 use App\Models\User;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 
 class UserRepository implements UserRepositoryInterface
@@ -30,5 +29,14 @@ class UserRepository implements UserRepositoryInterface
         $user = User::find(Auth::id());
         $user->have_thumbnail = $flag;
         $user->save();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function fetchNotifications(): mixed
+    {
+        $user = User::find(Auth::id());
+        return $user->notifications;
     }
 }

--- a/backend/app/Repositories/User/UserRepositoryInterface.php
+++ b/backend/app/Repositories/User/UserRepositoryInterface.php
@@ -4,6 +4,7 @@ namespace App\Repositories\User;
 
 use App\Http\Requests\ProfileRequest;
 use App\Models\User;
+use Notification;
 
 /**
  * interface UserRepository ユーザーのサムネイル処理
@@ -26,4 +27,11 @@ interface UserRepositoryInterface
      * @return void
      */
     public function toggleThumbnailFlag(bool $flag): void;
+
+    /**
+     * 通知一覧の取得
+     *
+     * @return mixed
+     */
+    public function fetchNotifications(): mixed;
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -59,3 +59,8 @@ Route::prefix('friend/request')->name('friend.request.')->group(function(){
     Route::get('/create', [FriendRequestController::class, 'create'])->name('create');
     Route::post('/store', [FriendRequestController::class, 'store'])->middleware(['friend.request'])->name('store');
 });
+
+// 通知取得
+Route::prefix('notifications')->name('notifications.')->group(function(){
+    Route::get('/', [UserController::class, 'notifications'])->name('all');
+});

--- a/backend/tests/Feature/FetchNotificationsTest.php
+++ b/backend/tests/Feature/FetchNotificationsTest.php
@@ -39,7 +39,7 @@ class FetchNotificationsTest extends TestCase
         $response = $this->actingAs($this->users[1])->get('/api/notifications');
 
         $response->assertStatus(200);
-
-        $this->assertCount(2, $response->notifications);
+        $response->assertJsonCount(2);
+        $this->assertEquals($response[0]['data']['message'], $friendRequestInfo['message']);
     }
 }


### PR DESCRIPTION
<!-- プルリクのタイトルはなるべく一行でわかるように書きましょう -->

## 目的
<!-- 変更の目的を書きましょう -->
ユーザーに紐づく通知一覧の取得実装

## チケットナンバー
<!-- 関連するBacklogのURLを貼りましょう -->
https://docs.google.com/document/d/1zbTVbyyw5TP7yIBRW-X2okib8JtYtu--aVvr-UD6ZyY/edit#heading=h.psy51f5situf

## 実装内容
<!-- できるだけ画像や動画を貼ってわかりやすくしましょう -->

## 再現手順
```bash
make test
```
<!-- レビュワーの考える手間が減るような雑すぎず細かすぎない手順を書いておいてあげましょう -->
<!-- 例: -->
<!-- http://localhost/hogehogeからfugaをクリック -->
<!-- →hogeボタンからhogefugaへ遷移してfugafugaを作成 -->

## チェックリスト

-   [ ] 他に依存するプルリクがないこと
-   [ ] CircleCI のテストを通過していること
-   [ ] コンフリクトしていないこと
